### PR TITLE
🐛 Fix dropping actors in firefox (doesn't support toElement)

### DIFF
--- a/scripts/party-sheet.js
+++ b/scripts/party-sheet.js
@@ -172,7 +172,8 @@ export class ForbiddenLandsPartySheet extends ActorSheet {
     }
 
     async handleTravelActionAssignment(event, actor) {
-        let actionContainer = event.toElement.classList.contains('travel-action') ? event.toElement : event.toElement.closest('.travel-action');
+        const targetElement = event.toElement ? event.toElement : event.target;
+        let actionContainer = targetElement.classList.contains('travel-action') ? targetElement : targetElement.closest('.travel-action');
         if (actionContainer === null) return; // character was dragged god knows where; just pretend it never happened
 
         this.assignPartyMembersToAction(actor, actionContainer.dataset.travelAction);


### PR DESCRIPTION
https://stackoverflow.com/questions/8600174/event-toelement-in-ie8-and-firefox

maybe it is better to just use .target everywhere? I think chrome supports this too and this would be the standard conformant way?